### PR TITLE
Update dependencies to support react v15

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "events": "^1.1.0"
   },
   "peerDependencies": {
-    "react": "^0.14.0"
+    "react": "^0.14.0 || ^15.0.0"
   },
   "devDependencies": {
     "@hokaccha/eslint-config": "^1.0.1",
@@ -44,8 +44,8 @@
     "espower-babel": "^4.0.1",
     "mocha": "^2.4.5",
     "power-assert": "^1.3.1",
-    "react": "^0.14.7",
-    "react-dom": "^0.14.7",
+    "react": "^15.0.2",
+    "react-dom": "^15.0.2",
     "sinon": "^1.17.3"
   }
 }


### PR DESCRIPTION
When installing this package in a project that uses React v15 the following warning is shown:

```
npm WARN react-micro-container@1.0.0 requires a peer of react@^0.14.0 but none was installed.
```

This pr solves that 🙏 
