### PR TITLE
let dispatch() to return whether the event is handled by someone or not

### DIFF
--- a/src/micro_container.js
+++ b/src/micro_container.js
@@ -14,7 +14,7 @@ export default class MicroContainer extends React.Component {
   }
 
   dispatch(...args) {
-    this.emitter.emit(...args);
+    return this.emitter.emit(...args);
   }
 
   subscribe(events) {

--- a/test/micro_container.js
+++ b/test/micro_container.js
@@ -37,4 +37,11 @@ describe('MicroContainer', () => {
     container.dispatch('foo');
     assert(spy.callCount === 1);
   });
+
+  it('should return true if evens are handled by someone', () => {
+    assert(container.dispatch('foo') === true);
+  });
+  it('should return false if evens are not handled', () => {
+    assert(container.dispatch('unknown_event') === false);
+  });
 });


### PR DESCRIPTION
I'd like to know whether `dispatch()` is consumed by someone or not.

For example, a multi-line input field, e.g. `textarea` based components, might consume `cmd+enter` as a `submit` shortcut, bot it's not always, so the container will call `disptch("submit")` and check the event is consumed or not. If false, the container goes fallback to default.
